### PR TITLE
Add offcanvas menu toggle to header

### DIFF
--- a/wp-content/themes/cdt-gp-child/assets/css/header.css
+++ b/wp-content/themes/cdt-gp-child/assets/css/header.css
@@ -3,8 +3,6 @@
     --topbar-bg:#f3f4f6;   /* grigio chiaro */
     --topbar-fg:#111827;
     --logobar-bg:#ffffff;  /* bianco */
-    --navbar-bg:#0b5ed7;   /* blu */
-    --navbar-fg:#ffffff;
     --ticker-bg:#e5e7eb;   /* grigio chiaro */
     --ticker-fg:#111827;
   }
@@ -27,16 +25,13 @@
   .cdt-logobar{background:var(--logobar-bg);transition:height .25s ease;box-shadow:0 1px 0 rgba(0,0,0,.04);}
   .cdt-logobar{height:120px;}
   .cdt-header.is-scrolled .cdt-logobar{height:60px;}
-  .cdt-logobar__inner{height:100%;display:flex;align-items:center;justify-content:center;}
-  .cdt-logo img{max-height:80px;transition:max-height .25s ease;}
-  .cdt-header.is-scrolled .cdt-logo img{max-height:48px;}
-  .site-title{font-size:1.5rem;text-decoration:none;color:inherit}
-  
-  /* 3) Navbar */
-  .cdt-navbar{background:var(--navbar-bg);color:var(--navbar-fg);}
-  .cdt-navbar .cdt-menu{display:flex;gap:24px;list-style:none;margin:0;padding:0;align-items:center;flex-wrap:wrap;}
-  .cdt-navbar .cdt-menu > li > a{display:block;color:var(--navbar-fg);text-decoration:none;padding:12px 0;font-weight:600;}
-  .cdt-navbar .cdt-menu > li > a:hover{opacity:.9;text-decoration:underline;}
+    .cdt-logobar__inner{height:100%;display:flex;align-items:center;justify-content:space-between;}
+    .cdt-logo img{max-height:80px;height:auto;width:auto;max-width:100%;transition:max-height .25s ease;}
+    .cdt-header.is-scrolled .cdt-logo img{max-height:48px;}
+    .site-title{font-size:1.5rem;text-decoration:none;color:inherit}
+    .cdt-menu-toggle{background:transparent;border:none;font-size:2rem;line-height:1;cursor:pointer;}
+    .cdt-offcanvas{position:fixed;top:0;right:0;height:100%;width:250px;background:var(--logobar-bg);box-shadow:-2px 0 8px rgba(0,0,0,.2);transform:translateX(100%);transition:transform .3s ease;z-index:1000;padding:1rem;}
+    .cdt-offcanvas.is-open{transform:translateX(0);}
   
   /* 4) Ticker */
   .cdt-tickerbar{background:var(--ticker-bg);color:var(--ticker-fg);border-top:1px solid rgba(0,0,0,.06);border-bottom:1px solid rgba(0,0,0,.06);}
@@ -51,10 +46,9 @@
   }
   
   /* Dark mode minimi */
-  @media (prefers-color-scheme: dark){
-    :root{--topbar-bg:#0f1114;--topbar-fg:#e5e7eb;--logobar-bg:#0b0b0c;--ticker-bg:#111316;--ticker-fg:#e5e7eb;}
-    .cdt-navbar{--navbar-bg:#0a3f8a;}
-  }
+    @media (prefers-color-scheme: dark){
+      :root{--topbar-bg:#0f1114;--topbar-fg:#e5e7eb;--logobar-bg:#0b0b0c;--ticker-bg:#111316;--ticker-fg:#e5e7eb;}
+    }
   body[data-theme="light"] { color-scheme: light; }
   body[data-theme="dark"]  { color-scheme: dark; }
   

--- a/wp-content/themes/cdt-gp-child/assets/js/header.js
+++ b/wp-content/themes/cdt-gp-child/assets/js/header.js
@@ -64,6 +64,18 @@
         // silenzioso
       }
     }
-    fetchWeather();
-  })();
+      fetchWeather();
+    
+      // ====== Offcanvas Menu ======
+      const toggle = document.querySelector('.cdt-menu-toggle');
+      const offcanvas = document.getElementById('cdt-offcanvas');
+      if (toggle && offcanvas) {
+        toggle.addEventListener('click', () => {
+          const open = offcanvas.classList.toggle('is-open');
+          toggle.setAttribute('aria-expanded', open);
+          if (open) offcanvas.removeAttribute('hidden');
+          else offcanvas.setAttribute('hidden', '');
+        });
+      }
+    })();
   

--- a/wp-content/themes/cdt-gp-child/header.php
+++ b/wp-content/themes/cdt-gp-child/header.php
@@ -36,12 +36,12 @@ if (!defined('ABSPATH')) exit;
           else echo '<a class="site-title" href="'.esc_url(home_url('/')).'">'.esc_html(get_bloginfo('name')).'</a>';
         ?>
       </div>
+      <button class="cdt-menu-toggle" aria-controls="cdt-offcanvas" aria-expanded="false" aria-label="Menu">☰</button>
     </div>
   </div>
 
-  <!-- 3) NAV BAR -->
-  <nav class="cdt-navbar" role="navigation" aria-label="<?php esc_attr_e('Primary', 'cdt-news'); ?>">
-    <div class="wrap">
+  <div id="cdt-offcanvas" class="cdt-offcanvas" hidden>
+    <div class="cdt-offcanvas__inner">
       <?php
       wp_nav_menu([
         'theme_location' => 'primary',
@@ -51,7 +51,7 @@ if (!defined('ABSPATH')) exit;
       ]);
       ?>
     </div>
-  </nav>
+  </div>
 
   <!-- 4) TICKER BAR -->
   <div class="cdt-tickerbar" role="region" aria-label="Ultime dalla sezione Striscia">


### PR DESCRIPTION
## Summary
- Add menu toggle icon beside logo and display WordPress nav inside an offcanvas panel
- Remove main navbar, keeping ticker as final header section
- Style and script offcanvas menu

## Testing
- `php -l wp-content/themes/cdt-gp-child/header.php`


------
https://chatgpt.com/codex/tasks/task_e_689dfa6ec734832c89b1fc8b94393c0b